### PR TITLE
お問い合わせフォームのリンクをGoogleフォームに更新

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "Bash(./update-function.sh)",
       "Bash(./remove-basic-auth.sh:*)",
       "Bash(rm:*)",
-      "Bash(git checkout:*)"
+      "Bash(git checkout:*)",
+      "Bash(gh pr create:*)"
     ],
     "deny": []
   }

--- a/getting-started.html
+++ b/getting-started.html
@@ -293,7 +293,7 @@
         <div class="container">
             <h2 style="color: #333; margin-bottom: 20px;">お問い合わせ</h2>
             <p>観光情報データの利用に関するご質問やご相談がございましたら、お気軽にお問い合わせください。</p>
-            <a href="mailto:info@japan-travel.or.jp?subject=観光情報データ利用について" class="contact-btn">お問い合わせフォーム</a>
+            <a href="https://docs.google.com/forms/d/e/1FAIpQLSc5VXOZ4ZwEmv5Ikxe6T4Pvfy530S7glpvD3M9umNwkseMjLA/viewform?usp=header" class="contact-btn" target="_blank">お問い合わせフォーム</a>
         </div>
     </section>
 


### PR DESCRIPTION
- メールリンクからGoogleフォームのURLに変更
- target="_blank"属性を追加して新規ウィンドウで開くように設定

🤖 Generated with [Claude Code](https://claude.ai/code)